### PR TITLE
Refactor: Update TabController listener in HomeView

### DIFF
--- a/lib/feature/home/presentation/views/home_view.dart
+++ b/lib/feature/home/presentation/views/home_view.dart
@@ -35,11 +35,11 @@ class _HomeViewState extends State<HomeView>
 
     isTabControllerInitialized = true;
 
-    _tabController.animation!.addListener(() {
-      final newIndex = _tabController.animation!.value.round();
-      if (newIndex != _selectedTabIndex) {
+    _tabController.addListener(() {
+      if (_tabController.indexIsChanging == false &&
+          _tabController.index != _selectedTabIndex) {
         setState(() {
-          _selectedTabIndex = newIndex;
+          _selectedTabIndex = _tabController.index;
           _getProducts(_selectedTabIndex);
         });
       }


### PR DESCRIPTION
- Modify `TabController` listener to update `_selectedTabIndex` and fetch products when the tab index changes and the animation is complete.
- Remove usage of `_tabController.animation!.value` and use `_tabController.index` and `_tabController.indexIsChanging` for more robust tab change detection.