### PR TITLE
feat: Implement caching strategy for home screen data

### DIFF
--- a/lib/core/helpers/hive_helper.dart
+++ b/lib/core/helpers/hive_helper.dart
@@ -1,4 +1,5 @@
 abstract class HiveHelper {
   static const String categoriesBox = 'categories_box';
   static const String productsBox = 'products_box';
+  static const cacheValidity = Duration(hours: 1);
 }

--- a/lib/core/helpers/shared_preferences_manager.dart
+++ b/lib/core/helpers/shared_preferences_manager.dart
@@ -5,6 +5,7 @@ class SharedPreferencesManager {
   static const String isUserLoggedInKey = 'isUserLoggedIn';
   static const String userTokenKey = 'userToken';
   static const String refreshTokenKey = 'refreshToken';
+  static const String lastFetchTimeKey = 'lastFetchTime';
 
   static Future<void> setFirstTime(bool isFirstTime) async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
@@ -44,5 +45,17 @@ class SharedPreferencesManager {
   static Future<String> getRefreshToken() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     return prefs.getString(refreshTokenKey) ?? '';
+  }
+
+  static Future<void> setLastFetchTime(DateTime time) async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(lastFetchTimeKey, time.millisecondsSinceEpoch);
+  }
+
+  static Future<DateTime?> getLastFetchTime() async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    final millis = prefs.getInt(lastFetchTimeKey);
+    if (millis == null) return null;
+    return DateTime.fromMillisecondsSinceEpoch(millis);
   }
 }

--- a/lib/feature/home/data/repo_implementation/data_sources/home_remote_data_source_imp.dart
+++ b/lib/feature/home/data/repo_implementation/data_sources/home_remote_data_source_imp.dart
@@ -7,6 +7,7 @@ import 'package:cartizy_app_nti/core/entities/product_entity.dart';
 import 'package:cartizy_app_nti/feature/home/domain/repo_contract/data_sources/home_remote_data_source.dart';
 import 'package:hive/hive.dart';
 import '../../../../../core/dtos/get_products_dto.dart';
+import '../../../../../core/helpers/shared_preferences_manager.dart';
 
 class HomeRemoteDataSourceImp implements HomeRemoteDataSource {
   HomeRemoteDataSourceImp(this._homeApi);
@@ -21,6 +22,7 @@ class HomeRemoteDataSourceImp implements HomeRemoteDataSource {
         List<CategoryEntity> categories =
             result.data?.map((e) => e.toEntity()).toList() ?? [];
         await _cacheCategories(categories);
+        await SharedPreferencesManager.setLastFetchTime(DateTime.now());
         return NetworkSuccess<List<CategoryEntity>>(categories);
       case NetworkFailure<List<GetAllCategoriesResponseDto>>():
         return NetworkFailure<List<CategoryEntity>>(result.exception);
@@ -37,6 +39,7 @@ class HomeRemoteDataSourceImp implements HomeRemoteDataSource {
         List<ProductEntity> products =
             result.data?.map((e) => e.toEntity()).toList() ?? [];
         await _cacheProducts(products);
+        await SharedPreferencesManager.setLastFetchTime(DateTime.now());
         return NetworkSuccess<List<ProductEntity>>(products);
       case NetworkFailure<List<GetProductsDto>>():
         return NetworkFailure<List<ProductEntity>>(result.exception);
@@ -51,6 +54,12 @@ class HomeRemoteDataSourceImp implements HomeRemoteDataSource {
 
   Future<void> _cacheProducts(List<ProductEntity> products) async {
     final box = await Hive.openBox<ProductEntity>(HiveHelper.productsBox);
-    await box.addAll(products);
+    var myBox = box.values
+        .where((element) => element.inCart || element.isFavorite)
+        .toList();
+    await box.clear();
+    var addedProducts = products.where((element) => !myBox.contains(element));
+    await box.addAll(myBox);
+    await box.addAll(addedProducts);
   }
 }

--- a/lib/feature/home/data/repo_implementation/repo/home_repo_imp.dart
+++ b/lib/feature/home/data/repo_implementation/repo/home_repo_imp.dart
@@ -1,9 +1,12 @@
+import 'package:cartizy_app_nti/core/helpers/hive_helper.dart';
 import 'package:cartizy_app_nti/core/helpers/network_response.dart';
 import 'package:cartizy_app_nti/feature/home/data/repo_implementation/data_sources/home_local_data_source_imp.dart';
 import 'package:cartizy_app_nti/feature/home/data/repo_implementation/data_sources/home_remote_data_source_imp.dart';
 import 'package:cartizy_app_nti/feature/home/domain/entities/category_entity.dart';
 import 'package:cartizy_app_nti/core/entities/product_entity.dart';
 import 'package:cartizy_app_nti/feature/home/domain/repo_contract/repo/home_repo.dart';
+
+import '../../../../../core/helpers/shared_preferences_manager.dart';
 
 class HomeRepoImp implements HomeRepo {
   HomeRepoImp(this._homeRemoteDataSourceImp, this._homeLocalDataSourceImp);
@@ -14,8 +17,12 @@ class HomeRepoImp implements HomeRepo {
   @override
   Future<NetworkResponse<List<CategoryEntity>>> getAllCategories() async {
     List<CategoryEntity> categories;
+    final lastFetch = await SharedPreferencesManager.getLastFetchTime();
+    final isCacheValid =
+        lastFetch != null &&
+        DateTime.now().difference(lastFetch) < HiveHelper.cacheValidity;
     categories = await _homeLocalDataSourceImp.getAllCategories();
-    if (categories.isEmpty) {
+    if (categories.isEmpty || !isCacheValid) {
       final result = await _homeRemoteDataSourceImp.getAllCategories();
       switch (result) {
         case NetworkSuccess<List<CategoryEntity>>():
@@ -34,9 +41,13 @@ class HomeRepoImp implements HomeRepo {
   Future<NetworkResponse<List<ProductEntity>>> getProductsByCategory(
     int categoryId,
   ) async {
+    final lastFetch = await SharedPreferencesManager.getLastFetchTime();
+    final isCacheValid =
+        lastFetch != null &&
+        DateTime.now().difference(lastFetch) < HiveHelper.cacheValidity;
     List<ProductEntity> products;
     products = await _homeLocalDataSourceImp.getProductsByCategory(categoryId);
-    if (products.isEmpty) {
+    if (products.isEmpty || !isCacheValid) {
       final result = await _homeRemoteDataSourceImp.getProductsByCategory(
         categoryId,
       );


### PR DESCRIPTION
- Add `SharedPreferencesManager` to store and retrieve the last fetch time for categories and products.
- Update `HomeRemoteDataSourceImp` to save the last fetch time after successfully fetching data.
- Modify `_cacheProducts` in `HomeRemoteDataSourceImp` to preserve products that are in the cart or marked as favorite when updating the cache.
- Update `HomeRepoImp` to check cache validity based on `lastFetchTime` and `cacheValidity` duration (1 hour) before fetching data from the remote source.
- Define `cacheValidity` constant in `HiveHelper`.