### PR TITLE
feat: Implement local caching for user profile

### DIFF
--- a/lib/core/entities/user_response_entity.dart
+++ b/lib/core/entities/user_response_entity.dart
@@ -1,3 +1,8 @@
+import 'package:hive/hive.dart';
+
+part 'user_response_entity.g.dart';
+
+@HiveType(typeId: 2)
 class UserResponseEntity {
   const UserResponseEntity({
     this.id = 0,
@@ -8,10 +13,16 @@ class UserResponseEntity {
     this.avatar = '',
   });
 
+  @HiveField(0)
   final int id;
+  @HiveField(1)
   final String email;
+  @HiveField(2)
   final String password;
+  @HiveField(3)
   final String name;
+  @HiveField(4)
   final String role;
+  @HiveField(5)
   final String avatar;
 }

--- a/lib/core/entities/user_response_entity.g.dart
+++ b/lib/core/entities/user_response_entity.g.dart
@@ -1,0 +1,56 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'user_response_entity.dart';
+
+// **************************************************************************
+// TypeAdapterGenerator
+// **************************************************************************
+
+class UserResponseEntityAdapter extends TypeAdapter<UserResponseEntity> {
+  @override
+  final int typeId = 2;
+
+  @override
+  UserResponseEntity read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return UserResponseEntity(
+      id: fields[0] as int,
+      email: fields[1] as String,
+      password: fields[2] as String,
+      name: fields[3] as String,
+      role: fields[4] as String,
+      avatar: fields[5] as String,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, UserResponseEntity obj) {
+    writer
+      ..writeByte(6)
+      ..writeByte(0)
+      ..write(obj.id)
+      ..writeByte(1)
+      ..write(obj.email)
+      ..writeByte(2)
+      ..write(obj.password)
+      ..writeByte(3)
+      ..write(obj.name)
+      ..writeByte(4)
+      ..write(obj.role)
+      ..writeByte(5)
+      ..write(obj.avatar);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UserResponseEntityAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/lib/core/helpers/dependency_injection.dart
+++ b/lib/core/helpers/dependency_injection.dart
@@ -11,6 +11,7 @@ import 'package:cartizy_app_nti/feature/home/domain/use_cases/get_all_categories
 import 'package:cartizy_app_nti/feature/home/domain/use_cases/get_products_by_category_use_case.dart';
 import 'package:cartizy_app_nti/feature/home/domain/use_cases/home_toggle_favorite.dart';
 import 'package:cartizy_app_nti/feature/profile/data/api/profile_api.dart';
+import 'package:cartizy_app_nti/feature/profile/data/repo_imp/data_sources/profile_local_data_source_imp.dart';
 import 'package:cartizy_app_nti/feature/profile/data/repo_imp/data_sources/profile_remote_data_source_imp.dart';
 import 'package:cartizy_app_nti/feature/profile/data/repo_imp/repo/profile_repo_imp.dart';
 import 'package:cartizy_app_nti/feature/search/data/api/search_api.dart';
@@ -108,7 +109,10 @@ void setupServiceLocator() {
 
   ///profile
   getIt.registerSingleton<ProfileRepoImp>(
-    ProfileRepoImp(ProfileRemoteDataSourceImp(ProfileApi.instance)),
+    ProfileRepoImp(
+      ProfileRemoteDataSourceImp(ProfileApi.instance),
+      ProfileLocalDataSourceImp(),
+    ),
   );
 
   getIt.registerSingleton<GetProfileUseCase>(

--- a/lib/core/helpers/hive_helper.dart
+++ b/lib/core/helpers/hive_helper.dart
@@ -1,5 +1,6 @@
 abstract class HiveHelper {
   static const String categoriesBox = 'categories_box';
   static const String productsBox = 'products_box';
+  static const String profileBox = 'profile_box';
   static const cacheValidity = Duration(hours: 1);
 }

--- a/lib/feature/profile/data/repo_imp/data_sources/profile_local_data_source_imp.dart
+++ b/lib/feature/profile/data/repo_imp/data_sources/profile_local_data_source_imp.dart
@@ -1,0 +1,12 @@
+import 'package:cartizy_app_nti/core/entities/user_response_entity.dart';
+import 'package:cartizy_app_nti/feature/profile/domain/repo_contract/data_sources/profile_local_data_source.dart';
+import 'package:hive/hive.dart';
+import '../../../../../core/helpers/hive_helper.dart';
+
+class ProfileLocalDataSourceImp implements ProfileLocalDataSource {
+  @override
+  Future<UserResponseEntity?> getProfile() async {
+    var box = Hive.box<UserResponseEntity>(HiveHelper.profileBox);
+    return box.values.isNotEmpty ? await Future.value(box.getAt(0)) : null;
+  }
+}

--- a/lib/feature/profile/data/repo_imp/data_sources/profile_remote_data_source_imp.dart
+++ b/lib/feature/profile/data/repo_imp/data_sources/profile_remote_data_source_imp.dart
@@ -3,10 +3,12 @@ import 'package:cartizy_app_nti/core/entities/user_response_entity.dart';
 import 'package:cartizy_app_nti/core/helpers/network_response.dart';
 import 'package:cartizy_app_nti/feature/profile/data/api/profile_api.dart';
 import 'package:cartizy_app_nti/feature/profile/domain/entities/upload_entity.dart';
-import 'package:cartizy_app_nti/feature/profile/domain/repo_contract/data_sources/profile_remote_data_source.dart';
+import 'package:hive/hive.dart';
 import 'package:image_picker/image_picker.dart';
 import '../../../../../core/dtos/user_response_dto.dart';
+import '../../../../../core/helpers/hive_helper.dart';
 import '../../../domain/entities/user_request_entity.dart';
+import '../../../domain/repo_contract/data_sources/profile_remote_data_source.dart';
 import '../../dtos/response/upload_response_dto.dart';
 
 class ProfileRemoteDataSourceImp implements ProfileRemoteDataSource {
@@ -19,7 +21,10 @@ class ProfileRemoteDataSourceImp implements ProfileRemoteDataSource {
     final response = await _profileApi.getProfile();
     switch (response) {
       case NetworkSuccess<UserResponseDto>():
-        return NetworkSuccess<UserResponseEntity>(response.data?.toEntity());
+        UserResponseEntity user =
+            response.data?.toEntity() ?? const UserResponseEntity();
+        _cacheProfile(user);
+        return NetworkSuccess<UserResponseEntity>(user);
       case NetworkFailure<UserResponseDto>():
         return NetworkFailure<UserResponseEntity>(response.exception);
     }
@@ -47,9 +52,18 @@ class ProfileRemoteDataSourceImp implements ProfileRemoteDataSource {
     );
     switch (response) {
       case NetworkSuccess<UserResponseDto>():
-        return NetworkSuccess<UserResponseEntity>(response.data?.toEntity());
+        UserResponseEntity user =
+            response.data?.toEntity() ?? const UserResponseEntity();
+        _cacheProfile(user);
+        return NetworkSuccess<UserResponseEntity>(user);
       case NetworkFailure<UserResponseDto>():
         return NetworkFailure<UserResponseEntity>(response.exception);
     }
+  }
+
+  Future<void> _cacheProfile(UserResponseEntity user) async {
+    final box = await Hive.openBox<UserResponseEntity>(HiveHelper.profileBox);
+    await box.clear();
+    await box.add(user);
   }
 }

--- a/lib/feature/profile/data/repo_imp/repo/profile_repo_imp.dart
+++ b/lib/feature/profile/data/repo_imp/repo/profile_repo_imp.dart
@@ -4,24 +4,37 @@ import 'package:cartizy_app_nti/feature/profile/domain/entities/upload_entity.da
 import 'package:cartizy_app_nti/feature/profile/domain/entities/user_request_entity.dart';
 import 'package:cartizy_app_nti/feature/profile/domain/repo_contract/repo/profile_repo.dart';
 import 'package:image_picker/image_picker.dart';
-import '../data_sources/profile_remote_data_source_imp.dart';
+import '../../../domain/repo_contract/data_sources/profile_local_data_source.dart';
+import '../../../domain/repo_contract/data_sources/profile_remote_data_source.dart';
 
 class ProfileRepoImp implements ProfileRepo {
-  ProfileRepoImp(this._profileRemoteDataSourceImp);
+  ProfileRepoImp(
+    this._profileRemoteDataSourceImp,
+    this._profileLocalDataSourceImp,
+  );
 
-  final ProfileRemoteDataSourceImp _profileRemoteDataSourceImp;
+  final ProfileRemoteDataSource _profileRemoteDataSourceImp;
+  final ProfileLocalDataSource _profileLocalDataSourceImp;
 
   @override
-  Future<NetworkResponse<UserResponseEntity>> getProfile() =>
-      _profileRemoteDataSourceImp.getProfile();
+  Future<NetworkResponse<UserResponseEntity>> getProfile() async {
+    UserResponseEntity? userFromLocal = await _profileLocalDataSourceImp
+        .getProfile();
+    if (userFromLocal != null) {
+      return NetworkSuccess<UserResponseEntity>(userFromLocal);
+    } else {
+      return await _profileRemoteDataSourceImp.getProfile();
+    }
+  }
 
   @override
-  Future<NetworkResponse<UploadEntity>> uploadImage(XFile file) =>
-      _profileRemoteDataSourceImp.uploadImage(file);
+  Future<NetworkResponse<UploadEntity>> uploadImage(XFile file) async =>
+      await _profileRemoteDataSourceImp.uploadImage(file);
 
   @override
   Future<NetworkResponse<UserResponseEntity>> updateProfile({
     required UserRequestEntity user,
     required int id,
-  }) => _profileRemoteDataSourceImp.updateProfile(user: user, id: id);
+  }) async =>
+      await _profileRemoteDataSourceImp.updateProfile(user: user, id: id);
 }

--- a/lib/feature/profile/domain/repo_contract/data_sources/profile_local_data_source.dart
+++ b/lib/feature/profile/domain/repo_contract/data_sources/profile_local_data_source.dart
@@ -1,0 +1,5 @@
+import '../../../../../core/entities/user_response_entity.dart';
+
+abstract class ProfileLocalDataSource {
+  Future<UserResponseEntity?> getProfile();
+}

--- a/lib/feature/profile/domain/use_cases/get_profile_use_case.dart
+++ b/lib/feature/profile/domain/use_cases/get_profile_use_case.dart
@@ -7,5 +7,6 @@ class GetProfileUseCase {
 
   final ProfileRepo _profileRepo;
 
-  Future<NetworkResponse<UserResponseEntity>> call() => _profileRepo.getProfile();
+  Future<NetworkResponse<UserResponseEntity>> call() async =>
+      await _profileRepo.getProfile();
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:hive_flutter/adapters.dart';
 import 'cartizy_app.dart';
+import 'core/entities/user_response_entity.dart';
 import 'core/helpers/dependency_injection.dart';
 import 'core/helpers/hive_helper.dart';
 import 'core/helpers/shared_preferences_manager.dart';
@@ -18,10 +19,12 @@ void main() async {
   await Hive.initFlutter();
   Hive.registerAdapter(CategoryEntityAdapter());
   Hive.registerAdapter(ProductEntityAdapter());
+  Hive.registerAdapter(UserResponseEntityAdapter());
 
   List result = await Future.wait([
     Hive.openBox<CategoryEntity>(HiveHelper.categoriesBox),
     Hive.openBox<ProductEntity>(HiveHelper.productsBox),
+    Hive.openBox<UserResponseEntity>(HiveHelper.profileBox),
     SharedPreferencesManager.getFirstTime(),
     SharedPreferencesManager.getUserLoggedIn(),
   ]);


### PR DESCRIPTION
- Add `ProfileLocalDataSource` and its implementation `ProfileLocalDataSourceImp` to handle local storage of user profile data using Hive.
- Generate `UserResponseEntityAdapter` for Hive compatibility.
- Update `ProfileRemoteDataSourceImp` to cache profile data after fetching from the network.
- Modify `ProfileRepoImp` to prioritize fetching profile data from local cache before making a network request.
- Register `UserResponseEntityAdapter` and open `profileBox` in `main.dart`.
- Update `GetProfileUseCase` to be asynchronous.
- Add `profileBox` constant to `HiveHelper`.
- Update dependency injection for `ProfileRepoImp` to include `ProfileLocalDataSourceImp`.
- Annotate `UserResponseEntity` with Hive annotations for local storage.